### PR TITLE
Upgrade examples to align on discover branch

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -90,9 +90,12 @@ open http://localhost:8888/simple_ext2/params/test?var1=foo
 Optionally, you can copy `simple_ext1.json` and `simple_ext2.json` configuration to your env `etc` folder and start only Extension 1, which will also start Extension 2.
 
 ```bash
-pip uninstall -y jupyter_simple_ext && \
+pip uninstall -y jupyter_server_example && \
   python setup.py install && \
   cp -r ./etc $(dirname $(which jupyter))/..
+```
+
+```bash
 # Start the jupyter server extension simple_ext1, it will also load simple_ext2 because of load_other_extensions = True..
 # When you invoke with the entrypoint, the default url will be opened in your browser.
 jupyter simple-ext1
@@ -102,18 +105,20 @@ jupyter simple-ext1
 
 Stop any running server (with `CTRL+C`) and start with additional configuration on the command line.
 
-The provided settings via CLI will override the configuration that reside in the files (`jupyter_simple_ext1_config.py`...)
+The provided settings via CLI will override the configuration that reside in the files (`jupyter_server_example1_config.py`...)
 
 ```bash
 jupyter simple-ext1 --SimpleApp1.configA="ConfigA from command line"
 ```
 
-Check the log, it should return on startup something like the following base on the trait you have defined in the CLI and in the `jupyter_simple_ext1_config.py`.
+Check the log, it should return on startup print the Config object.
+
+The content of the Config is based on the trait you have defined via the `CLI` and in the `jupyter_server_example1_config.py`.
 
 ```
 [SimpleApp1] Config {'SimpleApp1': {'configA': 'ConfigA from file', 'configB': 'ConfigB from file', 'configC': 'ConfigC from file'}}
 [SimpleApp1] Config {'SimpleApp1': {'configA': 'ConfigA from file', 'configB': 'ConfigB from file', 'configC': 'ConfigC from file'}}
-[SimpleApp2] WARNING | Config option `configD` not recognized by `SimpleApp2`.  Did you mean `config_file`?
+[SimpleApp2] WARNING | Config option `configD` not recognized by `SimpleApp2`.  Did you mean one of: `configA, configB, configC`?
 [SimpleApp2] Config {'SimpleApp2': {'configD': 'ConfigD from file'}}
 [SimpleApp1] Config {'SimpleApp1': {'configA': 'ConfigA from command line', 'configB': 'ConfigB from file', 'configC': 'ConfigC from file'}}
 ```
@@ -133,9 +138,10 @@ Try with the above links to check that only Extension 2 is responding (Extension
 
 `Extension 11` extends `Extension 1` and brings a few more configs.
 
-Run `jupyter simple-ext11 --generate-config && vi ~/.jupyter/jupyter_config.py`.
-
-> TODO `--generate-config` returns an exception `"The ExtensionApp has not ServerApp "`
+```bash
+# TODO `--generate-config` returns an exception `"The ExtensionApp has not ServerApp "`
+jupyter simple-ext11 --generate-config && vi ~/.jupyter/jupyter_config.py`.
+```
 
 The generated configuration should contains the following.
 
@@ -147,8 +153,9 @@ The `hello`, `ignore_js` and `simple11_dir` are traits defined on the SimpleApp1
 
 It also implements additional flags and aliases for these traits.
 
-+ The `--hello` flag will log on startup `Hello Simple11 - You have provided the --hello flag or defined a c.SimpleApp1.hello == True`.
-+ The `--simple11-dir` alias will set `SimpleExt11.simple11_dir` settings.
+- The `--hello` flag will log on startup `Hello Simple11 - You have provided the --hello flag or defined a c.SimpleApp1.hello == True`
+- The `ignore_js` flag
+- The `--simple11-dir` alias will set `SimpleExt11.simple11_dir` settings
 
 Stop any running server and then start the simple-ext11.
 

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -67,6 +67,12 @@ open http://localhost:8888/simple_ext1/redirect
 open http://localhost:8888/static/simple_ext1/favicon.ico
 ```
 
+You can also start the server extension with python modules.
+
+```bash
+python -m simple_ext1
+```
+
 ## Extension 1 and Extension 2
 
 The following command starts both the `simple_ext1` and `simple_ext2` extensions.

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -152,7 +152,7 @@ jupyter simple-ext11 --generate-config && vi ~/.jupyter/jupyter_config.py`.
 The generated configuration should contains the following.
 
 ```bash
-TBD
+# TODO
 ```
 
 The `hello`, `ignore_js` and `simple11_dir` are traits defined on the SimpleApp11 class.
@@ -167,6 +167,8 @@ Stop any running server and then start the simple-ext11.
 
 ```bash
 jupyter simple-ext11 --hello --simple11-dir any_folder
+# You can also launch with a module
+python -m simple_ext11 --hello
 # TODO FIX the following command, simple11 does not work launching with jpserver_extensions parameter.
 jupyter server --ServerApp.jpserver_extensions="{'simple_ext11': True}" --hello --simple11-dir any_folder
 ```

--- a/examples/simple/jupyter_simple_ext1_config.py
+++ b/examples/simple/jupyter_simple_ext1_config.py
@@ -1,3 +1,4 @@
 c.SimpleApp1.configA = 'ConfigA from file'
 c.SimpleApp1.configB = 'ConfigB from file'
 c.SimpleApp1.configC = 'ConfigC from file'
+c.SimpleApp1.configD = 'ConfigD from file'

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jupyter-simple-ext",
+  "name": "jupyter-server-example",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/examples/simple/setup.py
+++ b/examples/simple/setup.py
@@ -23,9 +23,9 @@ def get_data_files():
     return data_files
 
 setuptools.setup(
-    name = 'jupyter_simple_ext',
+    name = 'jupyter_server_example',
     version = VERSION,
-    description = 'Jupyter Simple Extension',
+    description = 'Jupyter Server Example',
     long_description = open('README.md').read(),
     packages = find_packages(),
     python_requires = '>=3.5',

--- a/examples/simple/simple_ext1/__init__.py
+++ b/examples/simple/simple_ext1/__init__.py
@@ -1,8 +1,9 @@
 from .application import SimpleApp1
 
 def _jupyter_server_extension_paths():
-    return [
-        {'module': 'simple_ext1'}
-    ]
+    return [{
+        'module': 'simple_ext1',
+        'app': SimpleApp1
+    }]
 
 load_jupyter_server_extension = SimpleApp1.load_jupyter_server_extension

--- a/examples/simple/simple_ext1/__main__.py
+++ b/examples/simple/simple_ext1/__main__.py
@@ -1,4 +1,7 @@
-from .application import main
+from traitlets import Dict
+
+from jupyter_server.serverapp import launch_new_instance, ServerApp
 
 if __name__ is '__main__':
-    main()
+    ServerApp.jpserver_extensions = Dict({'simple_ext1': True})
+    launch_new_instance()

--- a/examples/simple/simple_ext1/__main__.py
+++ b/examples/simple/simple_ext1/__main__.py
@@ -1,0 +1,4 @@
+from .application import main
+
+if __name__ is '__main__':
+    main()

--- a/examples/simple/simple_ext1/application.py
+++ b/examples/simple/simple_ext1/application.py
@@ -8,7 +8,7 @@ DEFAULT_STATIC_FILES_PATH = os.path.join(os.path.dirname(__file__), "static")
 DEFAULT_TEMPLATE_FILES_PATH = os.path.join(os.path.dirname(__file__), "templates")
 
 class SimpleApp1(ExtensionAppJinjaMixin, ExtensionApp):
-    
+
     # The name of the extension.
     extension_name = "simple_ext1"
 

--- a/examples/simple/simple_ext11/__init__.py
+++ b/examples/simple/simple_ext11/__init__.py
@@ -1,8 +1,11 @@
-from .application import SimpleApp1
+from .application import SimpleApp11
 
 def _jupyter_server_extension_paths():
     return [
-        {'module': 'simple_ext1'}
+        {
+            'module': 'simple_ext11',
+            'app': SimpleApp11
+        }
     ]
 
-load_jupyter_server_extension = SimpleApp1.load_jupyter_server_extension
+load_jupyter_server_extension = SimpleApp11.load_jupyter_server_extension

--- a/examples/simple/simple_ext11/__main__.py
+++ b/examples/simple/simple_ext11/__main__.py
@@ -1,0 +1,11 @@
+from traitlets import Dict
+
+from jupyter_server.serverapp import ServerApp
+
+if __name__ is '__main__':
+    ServerApp.jpserver_extensions = Dict({
+        'simple_ext1': False,
+        'simple_ext2': False,
+        'simple_ext11': True,
+        })
+    ServerApp.launch_instance()

--- a/examples/simple/simple_ext11/application.py
+++ b/examples/simple/simple_ext11/application.py
@@ -56,8 +56,8 @@ class SimpleApp11(SimpleApp1):
 
     def initialize_settings(self):
         self.log.info('hello: {}'.format(self.hello))
-        if self.config['hello'] == True:
-            self.log.info("Hello Simple11 - You have provided the --hello flag or defined 'c.SimpleApp1.hello == True' in jupyter_server_config.py")
+        if self.hello == True:
+            self.log.info("Hello Simple11: You have launched with --hello flag or defined 'c.SimpleApp1.hello == True' in your config file")
         self.log.info('ignore_js: {}'.format(self.ignore_js))
         super().initialize_settings()
 

--- a/examples/simple/simple_ext2/__init__.py
+++ b/examples/simple/simple_ext2/__init__.py
@@ -4,7 +4,7 @@ def _jupyter_server_extension_paths():
     return [
         {
             'module': 'simple_ext2',
-            'app': SimpleApp2,
+            'app': SimpleApp2
         },
     ]
 

--- a/examples/simple/simple_ext2/__init__.py
+++ b/examples/simple/simple_ext2/__init__.py
@@ -2,7 +2,10 @@ from .application import SimpleApp2
 
 def _jupyter_server_extension_paths():
     return [
-        {'module': 'simple_ext2'},
+        {
+            'module': 'simple_ext2',
+            'app': SimpleApp2,
+        },
     ]
 
 load_jupyter_server_extension = SimpleApp2.load_jupyter_server_extension

--- a/examples/simple/simple_ext2/__main__.py
+++ b/examples/simple/simple_ext2/__main__.py
@@ -3,5 +3,8 @@ from traitlets import Dict
 from jupyter_server.serverapp import ServerApp
 
 if __name__ is '__main__':
-    ServerApp.jpserver_extensions = Dict({'simple_ext1': True})
+    ServerApp.jpserver_extensions = Dict({
+        'simple_ext1': True,
+        'simple_ext2': True
+        })
     ServerApp.launch_instance()

--- a/examples/simple/simple_ext2/application.py
+++ b/examples/simple/simple_ext2/application.py
@@ -15,7 +15,7 @@ class SimpleApp2(ExtensionAppJinjaMixin, ExtensionApp):
     default_url = '/simple_ext2'
 
     # Should your extension expose other server extensions when launched directly?
-    load_other_extensions = False
+    load_other_extensions = True
 
     # Local path to static files directory.
     static_paths = [


### PR DESCRIPTION
Hi @Zsailer, this updates the examples to run again on the discover branch.

I have seen a regression when you provide a trait via CLI. It should override the value of the config file and it does not it anymore in the examples.

`jupyter simple-ext1 --SimpleApp1.configA="ConfigA from command line"` does to override configA (you can try, the log will print the details of the config).

Also, the flags are only accepted using entrypoints startup (as before) - This blocks me on the work for jupyterlab (the js test now are upgraded as extension, but they can be launched with flags, which breaks).

`jupyter simple-ext11 --hello` but `jupyter server --ServerApp.jpserver_extensions="{'simple_ext11': True}" --hello` does not
