### PR TITLE
Fix CI Failures

### DIFF
--- a/docs/source/developers/extensions.rst
+++ b/docs/source/developers/extensions.rst
@@ -87,6 +87,10 @@ Here is basic example:
         """
         await asyncio.sleep(.1)
 
+.. note:: The server startup banner (displaying server info and access URLs) is printed before starting asynchronous tasks, so those tasks might still be running even after the banner appears.
+
+..  WARNING: This note is also present in the "Starting asynchronous tasks from an ExtensionApp" section.
+   If you update it here, please update it there as well.
 
 Making an extension discoverable
 --------------------------------
@@ -385,6 +389,11 @@ Here is a basic (pseudo) code example:
 
         async def stop_extension(self):
             self.my_background_task.cancel()
+
+.. note:: The server startup banner (displaying server info and access URLs) is printed before starting asynchronous tasks, so those tasks might still be running even after the banner appears.
+
+..  WARNING: This note is also present in the "Starting asynchronous tasks from an extension" section.
+   If you update it here, please update it there as well.
 
 
 Distributing a server extension

--- a/examples/simple/pyproject.toml
+++ b/examples/simple/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "jupyter-server-example"
 description = "Jupyter Server Example"
 readme = "README.md"
-license = ""
+license = "BSD-3-Clause"
 requires-python = ">=3.8"
 dependencies = [
     "jinja2",

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -3061,6 +3061,24 @@ class ServerApp(JupyterApp):
                 )
                 self.exit(1)
 
+        info = self.log.info
+        for line in self.running_server_info(kernel_count=False).split("\n"):
+            info(line)
+        info(
+            _i18n(
+                "Use Control-C to stop this server and shut down all kernels (twice to skip confirmation)."
+            )
+        )
+        if "dev" in __version__:
+            info(
+                _i18n(
+                    "Welcome to Project Jupyter! Explore the various tools available"
+                    " and their corresponding documentation. If you are interested"
+                    " in contributing to the platform, please visit the community"
+                    " resources section at https://jupyter.org/community.html."
+                )
+            )
+
         self.write_server_info_file()
 
         if not self.no_browser_open_file:
@@ -3069,6 +3087,46 @@ class ServerApp(JupyterApp):
         # Handle the browser opening.
         if self.open_browser and not self.sock:
             self.launch_browser()
+
+        if self.identity_provider.token and self.identity_provider.token_generated:
+            # log full URL with generated token, so there's a copy/pasteable link
+            # with auth info.
+            if self.sock:
+                self.log.critical(
+                    "\n".join(
+                        [
+                            "\n",
+                            "Jupyter Server is listening on %s" % self.display_url,
+                            "",
+                            (
+                                "UNIX sockets are not browser-connectable, but you can tunnel to "
+                                f"the instance via e.g.`ssh -L 8888:{self.sock} -N user@this_host` and then "
+                                f"open e.g. {self.connection_url} in a browser."
+                            ),
+                        ]
+                    )
+                )
+            else:
+                if self.no_browser_open_file:
+                    message = [
+                        "\n",
+                        _i18n("To access the server, copy and paste one of these URLs:"),
+                        "    %s" % self.display_url,
+                    ]
+                else:
+                    message = [
+                        "\n",
+                        _i18n(
+                            "To access the server, open this file in a browser:",
+                        ),
+                        "    %s" % urljoin("file:", pathname2url(self.browser_open_file)),
+                        _i18n(
+                            "Or copy and paste one of these URLs:",
+                        ),
+                        "    %s" % self.display_url,
+                    ]
+
+                self.log.critical("\nDP_DAI2\n"+"\n".join(message))
 
     async def _cleanup(self) -> None:
         """General cleanup of files, extensions and kernels created
@@ -3126,64 +3184,6 @@ class ServerApp(JupyterApp):
             await self.extension_manager.start_all_extensions()
         except Exception as err:
             self.log.error(err)
-
-        info = self.log.info
-        for line in self.running_server_info(kernel_count=False).split("\n"):
-            info(line)
-        info(
-            _i18n(
-                "Use Control-C to stop this server and shut down all kernels (twice to skip confirmation)."
-            )
-        )
-        if "dev" in __version__:
-            info(
-                _i18n(
-                    "Welcome to Project Jupyter! Explore the various tools available"
-                    " and their corresponding documentation. If you are interested"
-                    " in contributing to the platform, please visit the community"
-                    " resources section at https://jupyter.org/community.html."
-                )
-            )
-
-        if self.identity_provider.token and self.identity_provider.token_generated:
-            # log full URL with generated token, so there's a copy/pasteable link
-            # with auth info.
-            if self.sock:
-                self.log.critical(
-                    "\n".join(
-                        [
-                            "\n",
-                            "Jupyter Server is listening on %s" % self.display_url,
-                            "",
-                            (
-                                "UNIX sockets are not browser-connectable, but you can tunnel to "
-                                f"the instance via e.g.`ssh -L 8888:{self.sock} -N user@this_host` and then "
-                                f"open e.g. {self.connection_url} in a browser."
-                            ),
-                        ]
-                    )
-                )
-            else:
-                if self.no_browser_open_file:
-                    message = [
-                        "\n",
-                        _i18n("To access the server, copy and paste one of these URLs:"),
-                        "    %s" % self.display_url,
-                    ]
-                else:
-                    message = [
-                        "\n",
-                        _i18n(
-                            "To access the server, open this file in a browser:",
-                        ),
-                        "    %s" % urljoin("file:", pathname2url(self.browser_open_file)),
-                        _i18n(
-                            "Or copy and paste one of these URLs:",
-                        ),
-                        "    %s" % self.display_url,
-                    ]
-
-                self.log.critical("\n".join(message))
 
     def start(self) -> None:
         """Start the Jupyter server app, after initialization

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -3126,7 +3126,7 @@ class ServerApp(JupyterApp):
                         "    %s" % self.display_url,
                     ]
 
-                self.log.critical("\nDP_DAI2\n"+"\n".join(message))
+                self.log.critical("\n".join(message))
 
     async def _cleanup(self) -> None:
         """General cleanup of files, extensions and kernels created


### PR DESCRIPTION
This PR fixes CI failures in JupyterLab downstream tests and test_examples.

- test_examples: Adding a license to pyproject.toml resolves the issue.
- JupyterLab downstream test: Followed Mike’s suggestion:
> move this block back to sync start_app and document that this message banner will be shown before the async extensions are registered. 

One thing I wasn't sure about—where should we document the message banner shown before async extensions are registered? And also I think we need to show some message after the async extensions are registered. Let me know your thoughts! 